### PR TITLE
Minor shell scripting improvements

### DIFF
--- a/kitchen
+++ b/kitchen
@@ -1,13 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-
-DOCKER_ARGS=""
-
-if [[ ! -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+if [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   DOCKER_ARGS="$(cat <<EOA
-  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-  -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+  -e AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_DEFAULT_REGION
 EOA
 )"
   echo "Using env variables for AWS creds"
@@ -16,5 +13,5 @@ else
   echo "Using ~/.aws creds"
 fi
   
-docker run --rm -v $(pwd):/workspace $DOCKER_ARGS \
-  joshmahowald/kitchen-terraform $@
+exec docker run --rm -v "$(pwd)":/workspace "$DOCKER_ARGS" \
+  joshmahowald/kitchen-terraform "$@"


### PR DESCRIPTION
Bit of a drive by PR but happened across this project when looking at Terraform testing stuff again:

I noticed the `! -z` which should really be `-n` (they're equivalent) and then decided to make some smaller fixes too.

You aren't doing anything clever in your test so you can use `[` instead of Bash's `[[` which means you can drop to a POSIX shell.

If you use `-e ENV_VAR_NAME` without specifying the value when running a Docker container it automatically sets it equal to the host's environment variable.

You were missing some quoting to help with awful people using spaces in files names/directory structures.

You can `exec` the `docker run` command to be using less processes which can be helpful in CI.

I've also ran it through [ShellCheck](https://github.com/koalaman/shellcheck) and it no longer complains about anything.